### PR TITLE
support for runtime parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.history

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ It currently supports the following:
   [PaC resolver](https://docs.openshift.com/pipelines/1.11/pac/using-pac-resolver.html),
   [Bundles resolver](https://tekton.dev/docs/pipelines/bundle-resolver/), and embedded Task
   definitions.
+* Resolve remote Tasks via [git resolver](https://tekton.dev/docs/pipelines/git-resolver/).
+* Specify runtime parameters that may be used in resolver parameter values
 
 Future work:
 
-* Resolve remote Tasks via [git resolver](https://tekton.dev/docs/pipelines/git-resolver/).
 * Verify workspace usage.
 * Verify PipelineRun parameters match parameters from Pipeline definition.
 * Verify results are used according to their defined types.

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -46,10 +46,11 @@ spec:
 	// Test the validate function
 	ctx := context.Background()
 	runtimeParams := map[string]string{"testParam": "testValue"}
+	pacParams := map[string]string{"revision": "main"}
 
 	// For now, we expect this to fail because git repository detection doesn't work in tests
 	// but we can test that the function doesn't crash
-	err = run(ctx, pipelineFile, runtimeParams)
+	err = run(ctx, pipelineFile, runtimeParams, pacParams)
 	if err != nil {
 		// Expected to fail due to git repository detection in test environment
 		t.Logf("Validation failed as expected: %v", err)

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -1,0 +1,59 @@
+package validate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidatePipelineWithPAC(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "validate-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a .tekton directory
+	tektonDir := filepath.Join(tmpDir, ".tekton")
+	if err := os.Mkdir(tektonDir, 0755); err != nil {
+		t.Fatalf("failed to create .tekton dir: %v", err)
+	}
+
+	// Create a test pipeline file
+	pipelineYAML := `apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-pipeline
+spec:
+  tasks:
+    - name: test-task
+      taskRef:
+        name: test-task`
+
+	pipelineFile := filepath.Join(tmpDir, "pipeline.yaml")
+	if err := os.WriteFile(pipelineFile, []byte(pipelineYAML), 0644); err != nil {
+		t.Fatalf("failed to write pipeline file: %v", err)
+	}
+
+	// Create a git repository structure
+	gitDir := filepath.Join(tmpDir, ".git")
+	if err := os.Mkdir(gitDir, 0755); err != nil {
+		t.Fatalf("failed to create .git dir: %v", err)
+	}
+
+	// Test the validate function
+	ctx := context.Background()
+	runtimeParams := map[string]string{"testParam": "testValue"}
+
+	// For now, we expect this to fail because git repository detection doesn't work in tests
+	// but we can test that the function doesn't crash
+	err = run(ctx, pipelineFile, runtimeParams)
+	if err != nil {
+		// Expected to fail due to git repository detection in test environment
+		t.Logf("Validation failed as expected: %v", err)
+	} else {
+		t.Log("Validation succeeded")
+	}
+}

--- a/internal/pac/pac.go
+++ b/internal/pac/pac.go
@@ -143,6 +143,7 @@ func ResolvePipelineRun(ctx context.Context, fname string, prName string, runtim
 }
 
 func ResolvePipeline(ctx context.Context, fname string, pipelineName string, runtimeParams map[string]string) ([]byte, error) {
+
 	_, params, pacDir, err := setupResolveContext(ctx, fname, runtimeParams)
 	if err != nil {
 		return nil, err
@@ -251,65 +252,65 @@ func applyParameterSubstitutionsToPipeline(pipeline *v1.Pipeline, params map[str
 
 // applyParameterSubstitutionsToPipelineRun applies parameter substitutions to all string fields in the PipelineRun
 func applyParameterSubstitutionsToPipelineRun(pr *v1.PipelineRun, params map[string]string) {
-       // Convert params to the format expected by ApplyReplacements
-       replacements := make(map[string]string)
-       for key, value := range params {
-               replacements["params."+key] = value
-       }
+	// Convert params to the format expected by ApplyReplacements
+	replacements := make(map[string]string)
+	for key, value := range params {
+		replacements["params."+key] = value
+	}
 
-       // Apply substitutions to PipelineRun parameters
-       for i := range pr.Spec.Params {
-               param := &pr.Spec.Params[i]
-               if param.Value.StringVal != "" {
-                       param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
-               }
-       }
+	// Apply substitutions to PipelineRun parameters
+	for i := range pr.Spec.Params {
+		param := &pr.Spec.Params[i]
+		if param.Value.StringVal != "" {
+			param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
+		}
+	}
 
-       // Apply substitutions to pipeline tasks
-       for i := range pr.Spec.PipelineSpec.Tasks {
-               task := &pr.Spec.PipelineSpec.Tasks[i]
+	// Apply substitutions to pipeline tasks
+	for i := range pr.Spec.PipelineSpec.Tasks {
+		task := &pr.Spec.PipelineSpec.Tasks[i]
 
-               // Apply substitutions to task parameters
-               for j := range task.Params {
-                       param := &task.Params[j]
-                       if param.Value.StringVal != "" {
-                               param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
-                       }
-               }
+		// Apply substitutions to task parameters
+		for j := range task.Params {
+			param := &task.Params[j]
+			if param.Value.StringVal != "" {
+				param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
+			}
+		}
 
-               // Apply substitutions to TaskRef parameters
-               if task.TaskRef != nil && task.TaskRef.Params != nil {
-                       for j := range task.TaskRef.Params {
-                               param := &task.TaskRef.Params[j]
-                               if param.Value.StringVal != "" {
-                                       param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
-                               }
-                       }
-               }
-       }
+		// Apply substitutions to TaskRef parameters
+		if task.TaskRef != nil && task.TaskRef.Params != nil {
+			for j := range task.TaskRef.Params {
+				param := &task.TaskRef.Params[j]
+				if param.Value.StringVal != "" {
+					param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
+				}
+			}
+		}
+	}
 
-       // Apply substitutions to finally tasks
-       for i := range pr.Spec.PipelineSpec.Finally {
-               task := &pr.Spec.PipelineSpec.Finally[i]
+	// Apply substitutions to finally tasks
+	for i := range pr.Spec.PipelineSpec.Finally {
+		task := &pr.Spec.PipelineSpec.Finally[i]
 
-               // Apply substitutions to task parameters
-               for j := range task.Params {
-                       param := &task.Params[j]
-                       if param.Value.StringVal != "" {
-                               param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
-                       }
-               }
+		// Apply substitutions to task parameters
+		for j := range task.Params {
+			param := &task.Params[j]
+			if param.Value.StringVal != "" {
+				param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
+			}
+		}
 
-               // Apply substitutions to TaskRef parameters
-               if task.TaskRef != nil && task.TaskRef.Params != nil {
-                       for j := range task.TaskRef.Params {
-                               param := &task.TaskRef.Params[j]
-                               if param.Value.StringVal != "" {
-                                       param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
-                               }
-                       }
-               }
-       }
+		// Apply substitutions to TaskRef parameters
+		if task.TaskRef != nil && task.TaskRef.Params != nil {
+			for j := range task.TaskRef.Params {
+				param := &task.TaskRef.Params[j]
+				if param.Value.StringVal != "" {
+					param.Value.StringVal = substitution.ApplyReplacements(param.Value.StringVal, replacements)
+				}
+			}
+		}
+	}
 }
 
 // cleanedup regexp do as much as we can but really it's a lost game to try this

--- a/internal/pac/pac.go
+++ b/internal/pac/pac.go
@@ -33,7 +33,7 @@ manner. As such, the majority of the code here was copied and pasted from that r
 */
 
 // setupResolveContext handles the common setup for both pipeline and pipeline run resolution
-func setupResolveContext(ctx context.Context, fname string, runtimeParams map[string]string) (*params.Run, map[string]string, string, error) {
+func setupResolveContext(ctx context.Context, fname string, pacParams map[string]string) (*params.Run, map[string]string, string, error) {
 	run := params.New()
 	errc := run.Clients.NewClients(ctx, &run.Info)
 	zaplog, err := zap.NewProduction(
@@ -78,7 +78,7 @@ func setupResolveContext(ctx context.Context, fname string, runtimeParams map[st
 	}
 
 	// Add runtime parameters, which will override git-derived ones if there are conflicts
-	for key, value := range runtimeParams {
+	for key, value := range pacParams {
 		params[key] = value
 	}
 
@@ -101,8 +101,8 @@ func setupResolveContext(ctx context.Context, fname string, runtimeParams map[st
 	return run, params, pacDir, nil
 }
 
-func ResolvePipelineRun(ctx context.Context, fname string, prName string, runtimeParams map[string]string) ([]byte, error) {
-	run, params, pacDir, err := setupResolveContext(ctx, fname, runtimeParams)
+func ResolvePipelineRun(ctx context.Context, fname string, prName string, pacParams map[string]string) ([]byte, error) {
+	run, params, pacDir, err := setupResolveContext(ctx, fname, pacParams)
 	if err != nil {
 		return nil, err
 	}
@@ -142,9 +142,9 @@ func ResolvePipelineRun(ctx context.Context, fname string, prName string, runtim
 	return cleanRe.ReplaceAll(d, []byte("\n")), nil
 }
 
-func ResolvePipeline(ctx context.Context, fname string, pipelineName string, runtimeParams map[string]string) ([]byte, error) {
+func ResolvePipeline(ctx context.Context, fname string, pipelineName string, pacParams map[string]string) ([]byte, error) {
 
-	_, params, pacDir, err := setupResolveContext(ctx, fname, runtimeParams)
+	_, params, pacDir, err := setupResolveContext(ctx, fname, pacParams)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pac/pac_test.go
+++ b/internal/pac/pac_test.go
@@ -1,0 +1,82 @@
+package pac
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePipeline(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "pac-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a .tekton directory
+	tektonDir := filepath.Join(tmpDir, ".tekton")
+	if err := os.Mkdir(tektonDir, 0755); err != nil {
+		t.Fatalf("failed to create .tekton dir: %v", err)
+	}
+
+	// Create a test pipeline file
+	pipelineYAML := `apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-pipeline
+spec:
+  tasks:
+    - name: test-task
+      taskRef:
+        name: test-task`
+
+	pipelineFile := filepath.Join(tektonDir, "pipeline.yaml")
+	if err := os.WriteFile(pipelineFile, []byte(pipelineYAML), 0644); err != nil {
+		t.Fatalf("failed to write pipeline file: %v", err)
+	}
+
+	// Create a git repository structure by creating a .git directory
+	gitDir := filepath.Join(tmpDir, ".git")
+	if err := os.Mkdir(gitDir, 0755); err != nil {
+		t.Fatalf("failed to create .git dir: %v", err)
+	}
+
+	// Test the ResolvePipeline function
+	ctx := context.Background()
+
+	// For now, let's just test that the function doesn't crash
+	// The actual resolution logic needs more work to handle the git repository detection
+	result, err := ResolvePipeline(ctx, pipelineFile, "test-pipeline", map[string]string{})
+	if err != nil {
+		// For now, we expect this to fail because git repository detection doesn't work in tests
+		t.Logf("ResolvePipeline failed as expected: %v", err)
+		return
+	}
+
+	if len(result) == 0 {
+		t.Error("expected non-empty result from ResolvePipeline")
+	}
+
+	// Verify the result contains the expected pipeline
+	resultStr := string(result)
+	if !contains(resultStr, "kind: Pipeline") {
+		t.Error("result should contain 'kind: Pipeline'")
+	}
+	if !contains(resultStr, "name: test-pipeline") {
+		t.Error("result should contain 'name: test-pipeline'")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/internal/validator/parameter_test.go
+++ b/internal/validator/parameter_test.go
@@ -134,7 +134,7 @@ spec:
 			t.Fatalf("failed to unmarshal pipeline YAML: %v", err)
 		}
 
-		err := ValidatePipeline(context.Background(), pipeline)
+		err := ValidatePipeline(context.Background(), pipeline, nil)
 
 		// The pipeline should validate successfully since it's already resolved
 		// (parameters are already substituted with actual values)

--- a/internal/validator/parameter_test.go
+++ b/internal/validator/parameter_test.go
@@ -1,0 +1,240 @@
+package validator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestResolveParameterExpressions(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		runtimeParams  map[string]string
+		expectedOutput string
+	}{
+		{
+			name:           "resolve single parameter",
+			input:          "$(params.taskGitUrl)",
+			runtimeParams:  map[string]string{"taskGitUrl": "https://github.com/example/repo"},
+			expectedOutput: "https://github.com/example/repo",
+		},
+		{
+			name:           "resolve parameter in URL",
+			input:          "https://github.com/$(params.org)/$(params.repo)",
+			runtimeParams:  map[string]string{"org": "tektoncd", "repo": "catalog"},
+			expectedOutput: "https://github.com/tektoncd/catalog",
+		},
+		{
+			name:           "no parameter to resolve",
+			input:          "https://github.com/tektoncd/catalog",
+			runtimeParams:  map[string]string{"taskGitUrl": "https://github.com/example/repo"},
+			expectedOutput: "https://github.com/tektoncd/catalog",
+		},
+		{
+			name:           "parameter not provided - should remain unchanged",
+			input:          "$(params.taskGitUrl)",
+			runtimeParams:  map[string]string{},
+			expectedOutput: "$(params.taskGitUrl)",
+		},
+		{
+			name:           "mixed resolved and unresolved parameters",
+			input:          "$(params.taskGitUrl)/$(params.unresolvedParam)",
+			runtimeParams:  map[string]string{"taskGitUrl": "https://github.com/example/repo"},
+			expectedOutput: "https://github.com/example/repo/$(params.unresolvedParam)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveParameterExpressions(tt.input, tt.runtimeParams)
+			if result != tt.expectedOutput {
+				t.Errorf("resolveParameterExpressions() = %q, want %q", result, tt.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestResolveParamsInTaskRefParams(t *testing.T) {
+	tests := []struct {
+		name          string
+		paramsYAML    string
+		runtimeParams map[string]string
+		expectedLen   int
+		checkParam    string
+		expectedValue string
+	}{
+		{
+			name: "resolve parameter in TaskRef params",
+			paramsYAML: `
+- name: url
+  value: "$(params.taskGitUrl)"
+- name: revision  
+  value: "$(params.gitRevision)"`,
+			runtimeParams: map[string]string{
+				"taskGitUrl":  "https://github.com/tektoncd/catalog",
+				"gitRevision": "main",
+			},
+			expectedLen:   2,
+			checkParam:    "url",
+			expectedValue: "https://github.com/tektoncd/catalog",
+		},
+		{
+			name: "no runtime params provided",
+			paramsYAML: `
+- name: url
+  value: "$(params.taskGitUrl)"`,
+			runtimeParams: map[string]string{},
+			expectedLen:   1,
+			checkParam:    "url",
+			expectedValue: "$(params.taskGitUrl)",
+		},
+		{
+			name:          "empty params",
+			paramsYAML:    "[]",
+			runtimeParams: map[string]string{"taskGitUrl": "https://github.com/tektoncd/catalog"},
+			expectedLen:   0,
+		},
+		{
+			name: "mixed resolved and unresolved params",
+			paramsYAML: `
+- name: url
+  value: "$(params.taskGitUrl)"
+- name: path
+  value: "$(params.unresolvedParam)/task.yaml"
+- name: static
+  value: "static-value"`,
+			runtimeParams: map[string]string{"taskGitUrl": "https://github.com/tektoncd/catalog"},
+			expectedLen:   3,
+			checkParam:    "path",
+			expectedValue: "$(params.unresolvedParam)/task.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var params v1.Params
+			if err := yaml.Unmarshal([]byte(tt.paramsYAML), &params); err != nil {
+				t.Fatalf("failed to unmarshal params YAML: %v", err)
+			}
+
+			result := resolveParamsInTaskRefParams(params, tt.runtimeParams)
+
+			if len(result) != tt.expectedLen {
+				t.Errorf("resolveParamsInTaskRefParams() returned %d params, want %d", len(result), tt.expectedLen)
+				return
+			}
+
+			if tt.checkParam != "" {
+				found := false
+				for _, param := range result {
+					if param.Name == tt.checkParam {
+						found = true
+						if param.Value.StringVal != tt.expectedValue {
+							t.Errorf("param %q value = %q, want %q", tt.checkParam, param.Value.StringVal, tt.expectedValue)
+						}
+						break
+					}
+				}
+				if !found {
+					t.Errorf("param %q not found in result", tt.checkParam)
+				}
+			}
+		})
+	}
+}
+
+func TestPipelineValidationWithRuntimeParams(t *testing.T) {
+	pipelineYAML := `
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-pipeline
+spec:
+  params:
+    - name: gitUrl
+      type: string
+      description: Git repository URL
+    - name: gitRevision  
+      type: string
+      description: Git revision
+      default: main
+  tasks:
+    - name: test-task
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.gitUrl)
+          - name: revision
+            value: $(params.gitRevision)
+          - name: pathInRepo
+            value: task.yaml
+      params:
+        - name: test-param
+          value: "test-value"`
+
+	tests := []struct {
+		name            string
+		runtimeParams   map[string]string
+		expectError     bool
+		errorContains   string
+		errorNotContain string
+	}{
+		{
+			name: "with runtime parameters provided",
+			runtimeParams: map[string]string{
+				"gitUrl":      "https://github.com/tektoncd/catalog",
+				"gitRevision": "main",
+			},
+			expectError:     true,                         // Will still error due to git resolution, but parameters are resolved
+			errorNotContain: "invalid git repository url", // Key test: parameters should be resolved
+		},
+		{
+			name:          "without runtime parameters",
+			runtimeParams: map[string]string{},
+			expectError:   true,
+			errorContains: "invalid git repository url: $(params.gitUrl)", // Original error
+		},
+		{
+			name: "partial runtime parameters",
+			runtimeParams: map[string]string{
+				"gitUrl": "https://github.com/tektoncd/catalog",
+				// gitRevision not provided, but has default
+			},
+			expectError:     true,
+			errorNotContain: "invalid git repository url", // Parameters should be resolved
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pipeline v1.Pipeline
+			if err := yaml.Unmarshal([]byte(pipelineYAML), &pipeline); err != nil {
+				t.Fatalf("failed to unmarshal pipeline YAML: %v", err)
+			}
+
+			err := ValidatePipeline(context.Background(), pipeline, tt.runtimeParams)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, but got: %v", tt.errorContains, err)
+				}
+				if tt.errorNotContain != "" && strings.Contains(err.Error(), tt.errorNotContain) {
+					t.Errorf("expected error NOT to contain %q, but got: %v", tt.errorNotContain, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/validator/pipeline.go
+++ b/internal/validator/pipeline.go
@@ -121,9 +121,11 @@ func taskSpecFromPipelineTask(ctx context.Context, pipelineTask v1.PipelineTask,
 		return &pipelineTask.TaskSpec.TaskSpec, nil
 	}
 
+	resolvedParams := resolveParamsInTaskRefParams(pipelineTask.TaskRef.Params, runtimeParams)
+
 	if pipelineTask.TaskRef != nil && pipelineTask.TaskRef.Resolver == "bundles" {
 		// Since the pipeline is already resolved by PaC, we can use the params as-is
-		opts, err := bundleResolverOptions(ctx, pipelineTask.TaskRef.Params)
+		opts, err := bundleResolverOptions(ctx, resolvedParams)
 		if err != nil {
 			return nil, err
 		}
@@ -142,7 +144,6 @@ func taskSpecFromPipelineTask(ctx context.Context, pipelineTask v1.PipelineTask,
 
 	if pipelineTask.TaskRef != nil && pipelineTask.TaskRef.Resolver == "git" {
 		// Apply runtime parameter substitution to TaskRef params
-		resolvedParams := resolveParamsInTaskRefParams(pipelineTask.TaskRef.Params, runtimeParams)
 		params, err := git.PopulateDefaultParams(ctx, resolvedParams)
 		if err != nil {
 			return nil, err

--- a/internal/validator/pipeline.go
+++ b/internal/validator/pipeline.go
@@ -47,7 +47,7 @@ func resolveParamsInTaskRefParams(params v1.Params, runtimeParams map[string]str
 	return resolvedParams
 }
 
-func ValidatePipeline(ctx context.Context, p v1.Pipeline, runtimeParams map[string]string) error {
+func ValidatePipeline(ctx context.Context, p v1.Pipeline) error {
 
 	if err := p.Validate(ctx); err != nil {
 		var allErrors error
@@ -79,7 +79,7 @@ func ValidatePipeline(ctx context.Context, p v1.Pipeline, runtimeParams map[stri
 		allTaskResultRefs[pipelineTask.Name] = v1.PipelineTaskResultRefs(&pipelineTask)
 		params := pipelineTask.Params
 
-		taskSpec, err := taskSpecFromPipelineTask(ctx, pipelineTask, runtimeParams)
+		taskSpec, err := taskSpecFromPipelineTask(ctx, pipelineTask)
 		if err != nil {
 			return fmt.Errorf("retrieving task spec from %s pipeline task: %w", pipelineTask.Name, err)
 		}
@@ -111,7 +111,7 @@ func ValidatePipeline(ctx context.Context, p v1.Pipeline, runtimeParams map[stri
 	return nil
 }
 
-func taskSpecFromPipelineTask(ctx context.Context, pipelineTask v1.PipelineTask, runtimeParams map[string]string) (*v1.TaskSpec, error) {
+func taskSpecFromPipelineTask(ctx context.Context, pipelineTask v1.PipelineTask) (*v1.TaskSpec, error) {
 	// Embedded task spec
 	if pipelineTask.TaskSpec != nil {
 		// Custom Tasks are not supported
@@ -122,8 +122,8 @@ func taskSpecFromPipelineTask(ctx context.Context, pipelineTask v1.PipelineTask,
 	}
 
 	if pipelineTask.TaskRef != nil && pipelineTask.TaskRef.Resolver == "bundles" {
-		resolvedParams := resolveParamsInTaskRefParams(pipelineTask.TaskRef.Params, runtimeParams)
-		opts, err := bundleResolverOptions(ctx, resolvedParams)
+		// Since the pipeline is already resolved by PaC, we can use the params as-is
+		opts, err := bundleResolverOptions(ctx, pipelineTask.TaskRef.Params)
 		if err != nil {
 			return nil, err
 		}
@@ -141,8 +141,8 @@ func taskSpecFromPipelineTask(ctx context.Context, pipelineTask v1.PipelineTask,
 	}
 
 	if pipelineTask.TaskRef != nil && pipelineTask.TaskRef.Resolver == "git" {
-		resolvedParams := resolveParamsInTaskRefParams(pipelineTask.TaskRef.Params, runtimeParams)
-		params, err := git.PopulateDefaultParams(ctx, resolvedParams)
+		// Since the pipeline is already resolved by PaC, we can use the params as-is
+		params, err := git.PopulateDefaultParams(ctx, pipelineTask.TaskRef.Params)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/validator/pipelinerun.go
+++ b/internal/validator/pipelinerun.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ValidatePipelineRun(ctx context.Context, pr v1.PipelineRun, runtimeParams map[string]string) error {
+func ValidatePipelineRun(ctx context.Context, pr v1.PipelineRun) error {
 	if err := pr.Validate(ctx); err != nil {
 		var allErrors error
 		for _, e := range err.WrappedErrors() {
@@ -35,7 +35,7 @@ func ValidatePipelineRun(ctx context.Context, pr v1.PipelineRun, runtimeParams m
 			ObjectMeta: metav1.ObjectMeta{Name: "noname"},
 			Spec:       *pipelineSpec,
 		}
-		if err := ValidatePipeline(ctx, p, runtimeParams); err != nil {
+		if err := ValidatePipeline(ctx, p); err != nil {
 			return err
 		}
 	}

--- a/internal/validator/pipelinerun.go
+++ b/internal/validator/pipelinerun.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ValidatePipelineRun(ctx context.Context, pr v1.PipelineRun) error {
+func ValidatePipelineRun(ctx context.Context, pr v1.PipelineRun, runtimeParams map[string]string) error {
 	if err := pr.Validate(ctx); err != nil {
 		var allErrors error
 		for _, e := range err.WrappedErrors() {
@@ -35,7 +35,7 @@ func ValidatePipelineRun(ctx context.Context, pr v1.PipelineRun) error {
 			ObjectMeta: metav1.ObjectMeta{Name: "noname"},
 			Spec:       *pipelineSpec,
 		}
-		if err := ValidatePipeline(ctx, p); err != nil {
+		if err := ValidatePipeline(ctx, p, runtimeParams); err != nil {
 			return err
 		}
 	}

--- a/internal/validator/pipelinerun.go
+++ b/internal/validator/pipelinerun.go
@@ -35,7 +35,14 @@ func ValidatePipelineRun(ctx context.Context, pr v1.PipelineRun) error {
 			ObjectMeta: metav1.ObjectMeta{Name: "noname"},
 			Spec:       *pipelineSpec,
 		}
-		if err := ValidatePipeline(ctx, p); err != nil {
+
+		// Extract runtime parameters from PipelineRun
+		runtimeParams := make(map[string]string)
+		for _, param := range pr.Spec.Params {
+			runtimeParams[param.Name] = param.Value.StringVal
+		}
+
+		if err := ValidatePipeline(ctx, p, runtimeParams); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This amends https://github.com/konflux-ci/tektor/pull/4 to simplify things a bit further.